### PR TITLE
最近のイベント履歴を表示するタブの実装

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1,5 +1,5 @@
 .App {
-  min-width: 320px;
+  min-width: 400px;
   text-align: center;
   display: flex;
   flex-direction: column;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,7 @@ import { TOPICS_STORAGE_KEY } from "./constants";
 import { Tab, Tabs, TabList, TabPanel } from "react-tabs";
 import TopicForm from "./components/TopicForm";
 import TopicList from "./components/TopicList";
+import History from "./components/History";
 import Config from "./components/Config";
 import "./App.css";
 import "react-tabs/style/react-tabs.css";
@@ -58,7 +59,8 @@ const App: React.FC = () => {
         <Tabs>
           <TabList>
             <Tab>トピック</Tab>
-            <Tab>設定</Tab>
+            <Tab>最近のイベント</Tab>
+            <Tab>通知設定</Tab>
           </TabList>
 
           <TabPanel>
@@ -71,6 +73,9 @@ const App: React.FC = () => {
               message={message}
               clearMessage={clearMessage}
             />
+          </TabPanel>
+          <TabPanel>
+            <History></History>
           </TabPanel>
           <TabPanel>
             <Config />

--- a/src/background.ts
+++ b/src/background.ts
@@ -2,19 +2,12 @@ import {
   API_BASE_URL,
   TOPICS_STORAGE_KEY,
   PLACE_STORAGE_KEY,
+  EVENTS_STORAGE_KEY,
   DEFAULT_PLACE_ID,
 } from "./constants";
 import axios from "axios";
 import qs from "qs";
-
-type Event = {
-  title: string;
-  url: string;
-  owner: string;
-  topic: string;
-  place: { lon: number; lat: number };
-};
-
+import { Event } from "./model/event";
 type NotiConnAPIResponse = {
   message: Array<Event>;
 };
@@ -30,6 +23,15 @@ const pushNotification = (event: Event) => {
   chrome.notifications.create(event.url, options);
 };
 
+const saveEvents = (events: Array<Event>) => {
+  if (events.length === 0) {
+    return;
+  }
+
+  events.splice(10);
+  localStorage.setItem(EVENTS_STORAGE_KEY, JSON.stringify(events));
+};
+
 const fetchEvents = async (topics: string[], place: string) => {
   await axios
     .get<NotiConnAPIResponse>(`${API_BASE_URL}/events`, {
@@ -40,6 +42,7 @@ const fetchEvents = async (topics: string[], place: string) => {
     })
     .then(response => {
       const { data: events } = response;
+      saveEvents(events.message);
       events.message.forEach(event => {
         pushNotification(event);
       });

--- a/src/background.ts
+++ b/src/background.ts
@@ -35,7 +35,7 @@ const saveEvents = (events: Array<Event>) => {
 const fetchEvents = async (topics: string[], place: string) => {
   await axios
     .get<NotiConnAPIResponse>(`${API_BASE_URL}/events`, {
-      params: { topics, place },
+      params: { topics, pref: place },
       paramsSerializer: params => {
         return qs.stringify(params, { arrayFormat: "repeat" });
       },

--- a/src/components/History/index.tsx
+++ b/src/components/History/index.tsx
@@ -1,0 +1,33 @@
+import React from "react";
+import { Event } from "../../model/event";
+import { EVENTS_STORAGE_KEY } from "../../constants";
+
+const History: React.FC = () => {
+  const newestEvents: Array<Event> = JSON.parse(
+    localStorage.getItem(EVENTS_STORAGE_KEY) || "[{}]"
+  );
+
+  return (
+    <div>
+      {newestEvents.map(event => {
+        return (
+          <div key={event.url} className="card">
+            <div className="card-content">
+              <div className="content">
+                <a href={event.url} target="_blank">
+                  {event.title}
+                </a>
+                <br />
+                <small>
+                  {event.topic}に関連 by {event.owner}
+                </small>
+              </div>
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+};
+
+export default History;

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1,6 +1,7 @@
 export const API_BASE_URL = process.env.API_URL;
 export const TOPICS_STORAGE_KEY = "topicsStorageKey";
 export const PLACE_STORAGE_KEY = "placeStorageKey";
+export const EVENTS_STORAGE_KEY = "eventsStorageKey";
 export const DEFAULT_PLACE_ID = "0";
 export const PLACES = {
   0: "リモート開催",

--- a/src/model/event.ts
+++ b/src/model/event.ts
@@ -1,0 +1,7 @@
+export type Event = {
+  title: string;
+  url: string;
+  owner: string;
+  topic: string;
+  place: { lon: number; lat: number };
+};


### PR DESCRIPTION
- 最近のイベント10件を表示するタブの追加
- Chromeストアでの公開タイミングを制御できないためクエリパラメータ名を前バージョンに合わせる